### PR TITLE
Fix compilation on GCC 12 on aarch64

### DIFF
--- a/src/util/demangle.cpp
+++ b/src/util/demangle.cpp
@@ -3,6 +3,8 @@
 
 #include <cxxabi.h>
 
+#include <utility>
+
 
 namespace util {
 


### PR DESCRIPTION
Add missing header. `std::exchange` resides in `<utility>`.